### PR TITLE
Added two extra UIAlertView APIs. Refactored the initWithTitle a bit for...

### DIFF
--- a/LMAlertView/LMAlertView.h
+++ b/LMAlertView/LMAlertView.h
@@ -28,6 +28,7 @@
 #define kSpringAnimationClassName RBBSpringAnimation
 #endif
 
+
 @interface LMAlertView : UIView <UITableViewDataSource, UITableViewDelegate>
 
 @property (nonatomic, strong) UIColor *tintColor;
@@ -54,6 +55,8 @@
 
 - (void)show;
 - (void)dismissWithClickedButtonIndex:(NSInteger)buttonIndex animated:(BOOL)animated;
+- (NSInteger)addButtonWithTitle:(NSString *)title;
+- (NSString *)buttonTitleAtIndex:(NSInteger)buttonIndex;
 
 - (LMModalItemTableViewCell *)buttonCellForIndex:(NSInteger)buttonIndex;
 

--- a/LMAlertViewDemo/LMViewController.m
+++ b/LMAlertViewDemo/LMViewController.m
@@ -97,8 +97,13 @@
 
 - (IBAction)customButtonTapped:(id)sender
 {
-	LMAlertView *alertView = [[LMAlertView alloc] initWithTitle:@"Test" message:@"Message here" delegate:self cancelButtonTitle:@"Cancel" otherButtonTitles:@"OK", nil];
-	
+    LMAlertView *alertView = [[LMAlertView alloc] initWithTitle:@"Test" message:@"Message here" delegate:self cancelButtonTitle:@"Cancel" otherButtonTitles:@"OK", nil];
+
+    //[alertView addButtonWithTitle:@"3rd"];
+    for (NSInteger titleIndex = 0; titleIndex < alertView.numberOfButtons; titleIndex++) {
+        NSLog(@"%@: button title for index %i is: %@", [alertView class], titleIndex, [alertView buttonTitleAtIndex:titleIndex]);
+    }
+    
 	NSLog(@"%@: First other button index: %li", [alertView class], (long)alertView.firstOtherButtonIndex);
 	NSLog(@"%@: Cancel button index: %li", [alertView class], (long)alertView.cancelButtonIndex);
 	NSLog(@"%@: Number of buttons: %li", [alertView class], (long)alertView.numberOfButtons);


### PR DESCRIPTION
... this. Demo code in the “Custom” button of the demo project

When these two new methods are available, it is easier to write a block-based wrapping for LMAlertView. LMAlertView. LMAlertView can then be a drop-in replacement for UIAlertView in for instance code like https://github.com/jivadevoe/UIAlertView-Blocks
