### PR TITLE
In IOS 6, the background color of the titleLabel and messageLabel appear...

### DIFF
--- a/LMAlertView/LMAlertView.m
+++ b/LMAlertView/LMAlertView.m
@@ -171,6 +171,7 @@
         self.titleLabel = [[UILabel alloc] init];
         self.titleLabel.numberOfLines = 0;
         self.titleLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+        self.titleLabel.backgroundColor = [UIColor clearColor]; // IOS 6
         self.title = title;
 
         CGSize sizeThatFits = [self.titleLabel sizeThatFits:CGSizeMake(labelWidth, MAXFLOAT)];
@@ -187,6 +188,7 @@
         self.messageLabel = [[UILabel alloc] init];
         self.messageLabel.numberOfLines = 0;
         self.messageLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+        self.messageLabel.backgroundColor = [UIColor clearColor]; // IOS 6
         self.message = message;
 
         CGSize sizeThatFits = [self.messageLabel sizeThatFits:CGSizeMake(labelWidth, MAXFLOAT)];


### PR DESCRIPTION
... white

This update puts the background color to clear so it appears like the rest of the alertView. This is forward compatible with IOS 7
