### PR TITLE
prevent crash when the visible view controller holds a reference to a ma...

### DIFF
--- a/LMAlertView/CALayer+ModalAlert.m
+++ b/LMAlertView/CALayer+ModalAlert.m
@@ -27,7 +27,7 @@
 {
 	UIView *tempView = view;
 	
-	while (tempView.superview != nil) {
+	while ([tempView respondsToSelector:@selector(superview)] && tempView.superview != nil) {
 		tempView = tempView.superview;
 		
 		if ([tempView isKindOfClass:[UIWindow class]]) {


### PR DESCRIPTION
...p view. The error message was: -[VKMapView superview]: unrecognized selector sent to instance ...
