### PR TITLE
Propagate tint color to alert view buttons.

### DIFF
--- a/LMAlertView/LMAlertView.m
+++ b/LMAlertView/LMAlertView.m
@@ -679,7 +679,8 @@
 	cell.lineView.hidden = lastRow;
 	cell.textLabel.font = boldButton ? [UIFont boldSystemFontOfSize:17.0] : [UIFont systemFontOfSize:17.0];
 	cell.textLabel.text = labelText;
-	
+    cell.textLabel.textColor = self.tintColor;
+    
 	return cell;
 }
 


### PR DESCRIPTION
This would then allow LMAlertView to show blue buttons, just like UIAlertView, with just a one-liner:

```
alertView.tintColor = [UIView new].tintColor; // default iOS (blue) tint color
```
