### PR TITLE
Fixed crash when is added CAKeyframeAnimation

### DIFF
--- a/LMAlertView/CALayer+ModalAlert.m
+++ b/LMAlertView/CALayer+ModalAlert.m
@@ -42,7 +42,7 @@
 	UIView *view = [self delegate];
 	UIWindow *window = [self windowForView:view];
 	
-	if ([window.rootViewController isKindOfClass:[LMEmbeddedViewController class]]) {
+	if ([window.rootViewController isKindOfClass:[LMEmbeddedViewController class]] && [anim isKindOfClass:[CABasicAnimation class]]) {
 		CABasicAnimation *basicAnim = (CABasicAnimation *)anim;
 		CGFloat modalWidth = 290.0;
 		


### PR DESCRIPTION
Crash occur when want to add an CAKeyframeAnimation. It's not responds to selector @fromValue.
