### PR TITLE
Make LMAlertView ready to be used as dynamic framework

### DIFF
--- a/LMAlertView/LMAlertView.h
+++ b/LMAlertView/LMAlertView.h
@@ -24,7 +24,7 @@
 - (float)velocity;
 @end
 #else
-#import <RBBSpringAnimation.h>
+#import "RBBSpringAnimation.h"
 #define kSpringAnimationClassName RBBSpringAnimation
 #endif
 

--- a/LMAlertView/LMAlertView.m
+++ b/LMAlertView/LMAlertView.m
@@ -9,7 +9,7 @@
 #import "LMAlertView.h"
 #import "LMEmbeddedViewController.h"
 #import "LMModalItemTableViewCell.h"
-#import <CAAnimation+Blocks.h>
+#import "CAAnimation+Blocks.h"
 
 @interface LMAlertView ()
 


### PR DESCRIPTION
This fixes import issues when using LMAlertView as an dynamic framework.
